### PR TITLE
Add parsedownparty_autoenable filter (fixes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
-# Parsedown Party
+# Parsedown Party 
 
-[![Build Status](https://travis-ci.org/connerbw/parsedownparty.svg?branch=master)](https://travis-ci.org/connerbw/parsedownparty) [![Code Coverage](https://codecov.io/gh/connerbw/parsedownparty/branch/master/graph/badge.svg)](https://codecov.io/gh/connerbw/parsedownparty) [![Packagist](https://img.shields.io/packagist/v/connerbw/parsedownparty.svg)](https://packagist.org/packages/connerbw/parsedownparty)
-
-**Contributors:** conner_bw  
+**Contributors:** conner_bw, greatislander  
 **Tags:** markdown, parsedown  
 **Requires at least:** 4.9  
 **Tested up to:** 4.9  
 **Requires PHP:** 5.6  
 **Stable tag:** trunk  
 **License:** GPLv2  
-**License URI:** https://www.gnu.org/licenses/gpl-2.0.en.html
+**License URI:** https://www.gnu.org/licenses/gpl-2.0.en.html  
 
-Markdown editing for WordPress.  
+[![Build Status](https://travis-ci.org/connerbw/parsedownparty.svg?branch=master)](https://travis-ci.org/connerbw/parsedownparty) [![Code Coverage](https://codecov.io/gh/connerbw/parsedownparty/branch/master/graph/badge.svg)](https://codecov.io/gh/connerbw/parsedownparty) [![Packagist](https://img.shields.io/packagist/v/connerbw/parsedownparty.svg)](https://packagist.org/packages/connerbw/parsedownparty)
+
+Markdown editing for WordPress.
+
 
 ## Description 
 
-This plugin lets you use [Markdown](https://github.com/erusev/parsedown) for individual posts on a case-by-case basis. Markdown can be activated using a toggle in the post editor
-submit box. When enabled, it replaces the WordPress post editor with [CodeMirror](https://make.wordpress.org/core/2017/10/22/code-editing-improvements-in-wordpress-4-9/) in
-Markdown mode.
+This plugin lets you use [Markdown](https://github.com/erusev/parsedown) for individual posts on a case-by-case basis. Markdown can be activated using a toggle in the post editor submit box. When enabled, it replaces the WordPress post editor with [CodeMirror](https://make.wordpress.org/core/2017/10/22/code-editing-improvements-in-wordpress-4-9/) in Markdown mode.
+
 
 ## Screenshots 
 
-![Screenshot 1](screenshot-1.png "Parsedown Party in the post editor.")
+### 1. Parsedown Party in the post editor.
+![Parsedown Party in the post editor.](https://ps.w.org/parsedown-party/assets/screenshot-1.png)
+
 
 
 ## Frequently Asked Questions 
@@ -32,23 +34,33 @@ Markdown mode.
 Yes.
 
 
-### Is this Plugin compatible with [Pressbooks](https://pressbooks.org/)? 
+### Can I automatically enable Markdown for all new posts? 
 
-Yes.
+Yes. Add the following line to your theme's `functions.php` (or another suitable place):
+
+```
+add_filter( 'parsedownparty_autoenable', '__return_true' );
+```
+
+
+### Is this Plugin compatible with Pressbooks? 
+
+[Yes.](https://pressbooks.org/)
 
 
 ### I'm a software developer, how can I help? 
 
 This plugin follows [Pressbooks coding standards](https://docs.pressbooks.org/coding-standards/) and development [happens on GitHub](https://github.com/connerbw/parsedownparty).
 
-The philosophy behind this plugin is: Take a best of breed [Markdown Parser](https://github.com/erusev/parsedown), combine it with WordPress' built-in [CodeMirror](https://make.wordpress.org/core/2017/10/22/code-editing-improvements-in-wordpress-4-9/)
-libraries, and let users write posts in Markdown. Things like two-pane WYSIWYG editors are out of scope for this particular plugin (the Preview button works fine.) The design goal
-is to modify WordPress Core as little as possible while providing decent Markdown support for content.
+The philosophy behind this plugin is: Take a best of breed [Markdown Parser](https://github.com/erusev/parsedown), combine it with WordPress' built-in [CodeMirror](https://make.wordpress.org/core/2017/10/22/code-editing-improvements-in-wordpress-4-9/) libraries, and let users write posts in Markdown. Things like two-pane WYSIWYG editors are out of scope for this particular plugin (the Preview button works fine.) The design goal is to modify WordPress Core as little as possible while providing decent Markdown support for content.
 
 
 ## Changelog 
 
 
-### 1.0.0  
-Initial release.
+### 1.1.0 
+Add `parsedownparty_autoenable` filter to allow Markdown to be enabled by default. 
 
+
+### 1.0.0 
+Initial release.

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -21,7 +21,7 @@ class Plugin {
 	/**
 	 * @var array
 	 */
-	private $supportedPages = [ 'post.php' ];
+	private $supportedPages = [ 'post.php', 'post-new.php' ];
 
 	/**
 	 * @return Plugin
@@ -69,10 +69,23 @@ class Plugin {
 				$post = get_post( $id );
 			}
 		}
-		if ( $post && get_post_meta( $post->ID, self::METAKEY, true ) ) {
-			return true;
+		if ( $post ) {
+			$meta_value = get_post_meta( $post->ID, self::METAKEY, true );
 		}
-		return false;
+		if ( $post && absint( $meta_value ) === 1 ) {
+			return true;
+		} elseif ( $post && $meta_value === '0' ) {
+			// If post meta is set to 0 (not false), disable Markdown
+			return false;
+		}
+		/**
+		 * Enable markdown by default:
+		 *
+		 *    add_filter('parsedownparty_autoenable', '__return_true');
+		 *
+		 * @since 1.1
+		 */
+		return apply_filters( 'parsedownparty_autoenable', false );
 	}
 
 	/**
@@ -124,7 +137,7 @@ class Plugin {
 		if ( ! empty( $_POST[ self::METAKEY ] ) ) {
 			update_post_meta( $post_id, self::METAKEY, 1 );
 		} else {
-			delete_post_meta( $post_id, self::METAKEY );
+			update_post_meta( $post_id, self::METAKEY, 0 );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Parsedown Party ===
 
-Contributors: conner_bw
+Contributors: conner_bw, greatislander
 Tags: markdown, parsedown
 Requires at least: 4.9
 Tested up to: 4.9
@@ -8,6 +8,8 @@ Requires PHP: 5.6
 Stable tag: trunk
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.en.html
+
+[![Build Status](https://travis-ci.org/connerbw/parsedownparty.svg?branch=master)](https://travis-ci.org/connerbw/parsedownparty) [![Code Coverage](https://codecov.io/gh/connerbw/parsedownparty/branch/master/graph/badge.svg)](https://codecov.io/gh/connerbw/parsedownparty) [![Packagist](https://img.shields.io/packagist/v/connerbw/parsedownparty.svg)](https://packagist.org/packages/connerbw/parsedownparty)
 
 Markdown editing for WordPress.
 
@@ -25,6 +27,14 @@ This plugin lets you use [Markdown](https://github.com/erusev/parsedown) for ind
 
 Yes.
 
+= Can I automatically enable Markdown for all new posts? =
+
+Yes. Add the following line to your theme's `functions.php` (or another suitable place):
+
+```
+add_filter( 'parsedownparty_autoenable', '__return_true' );
+```
+
 = Is this Plugin compatible with Pressbooks? =
 
 [Yes.](https://pressbooks.org/)
@@ -36,6 +46,9 @@ This plugin follows [Pressbooks coding standards](https://docs.pressbooks.org/co
 The philosophy behind this plugin is: Take a best of breed [Markdown Parser](https://github.com/erusev/parsedown), combine it with WordPress' built-in [CodeMirror](https://make.wordpress.org/core/2017/10/22/code-editing-improvements-in-wordpress-4-9/) libraries, and let users write posts in Markdown. Things like two-pane WYSIWYG editors are out of scope for this particular plugin (the Preview button works fine.) The design goal is to modify WordPress Core as little as possible while providing decent Markdown support for content.
 
 == Changelog ==
+
+= 1.1.0 =
+Add `parsedownparty_autoenable` filter to allow Markdown to be enabled by default. 
 
 = 1.0.0 =
 Initial release.

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -38,6 +38,10 @@ class PluginTest extends WP_UnitTestCase {
 		$this->assertFalse( $this->plugin->useMarkdownForPost( $post ) );
 		update_post_meta( $post->ID, Plugin::METAKEY, 1 );
 		$this->assertTrue( $this->plugin->useMarkdownForPost( $post ) );
+		$new_post = $this->factory()->post->create_and_get();
+		add_filter( 'parsedownparty_autoenable', '__return_true' );
+		$this->assertTrue( $this->plugin->useMarkdownForPost( $post ) );
+		remove_filter( 'parsedownparty_autoenable', '__return_true' );		
 	}
 
 	public function test_useMarkdownForPost_Pressbooks_Export() {


### PR DESCRIPTION
This PR:

+ Adds the [`parsedownparty_autoenable`](https://github.com/greatislander/parsedownparty/blob/a6f58c2b87c67cf705718f1193da7145c57dbb51/inc/class-plugin.php#L81-L88) filter for enabling Markdown by default (fixes #2)
+ Allows Markdown to be disabled on a per-post basis by saving a zero-value to `Plugin::METAKEY`
+ Applies editor changes to `post-new.php` so that the new post screen will use the Markdown editor when enabled by default.